### PR TITLE
Add application level retry functionality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     "no-underscore-dangle": "off",
     "class-methods-use-this": "off",
     "import/no-named-as-default-member": "off",
+    "no-console": "error",
   },
   "plugins": [
     "flowtype",

--- a/src/AMQPAdapter.js
+++ b/src/AMQPAdapter.js
@@ -58,6 +58,8 @@ class AMQPAdapter {
   _state: _State = 'idle';
   _eventBus: AMQPAdapterEventBus = (new EventEmitter(): any);
   _inflightHandlers: number = 0;
+  // @todo: add normal logger injection
+  // eslint-disable-next-line no-console
   _errorHandler: Error => mixed = err => console.error(err);
   _activeConsumers: string[] = [];
 
@@ -224,7 +226,7 @@ class AMQPAdapter {
 
         this._inflightHandlers += 1;
         try {
-          const message = new AMQPMessage(originalMessage, this._channel);
+          const message = new AMQPMessage(originalMessage, this._channel, queue);
           await (handler: any)(message);
         } catch (err) {
           this._errorHandler(

--- a/src/AMQPMessage.test.js
+++ b/src/AMQPMessage.test.js
@@ -1,57 +1,25 @@
-/* eslint-disable no-param-reassign */
 import test from 'ava';
-import uuid from 'uuid/v4';
 import AMQPMessage from './AMQPMessage';
+import {
+  createAmqpMessageMock,
+  createChannelMock,
+  createAmqpMessageObjectMock,
+} from './AMQPMessageMock';
 
-test.beforeEach(t => {
-  const ctx = {};
-  t.context = ctx;
-
-  ctx.channel = {
-    ack: () => {},
-    reject: () => {},
-  };
-
-  ctx.getAmqpMessageObject = (payloadBuffer, contentType) => ({
-    content: payloadBuffer,
-    fields: {
-      deliveryTag: uuid(),
-      consumerTag: uuid(),
-      exchange: '',
-      routingKey: uuid(),
-      redelivered: false,
-    },
-    properties: {
-      expiration: '1000',
-      userId: uuid(),
-      CC: '',
-      priority: 100,
-      persistent: true,
-      contentType,
-      contentEncoding: 'utf-8',
-      headers: {},
-      correlationId: uuid(),
-      replyTo: uuid(),
-      messageId: uuid(),
-      timestamp: Date.now(),
-      type: uuid(),
-      appId: uuid(),
-    },
+test('construct AMQPMessage', t => {
+  const amqpMessage = createAmqpMessageObjectMock({
+    payload: { foo: 42 },
   });
-});
+  const channel = createChannelMock();
 
-test('construct', t => {
-  const amqpMessage = t.context.getAmqpMessageObject(Buffer.from('1'));
-  const message = new AMQPMessage(amqpMessage, t.context.channel);
-  t.true(message instanceof AMQPMessage);
+  t.notThrows(() => new AMQPMessage(amqpMessage, channel));
 });
 
 test('get payload object', t => {
   const payload = { foo: 42 };
   const payloadAsString = JSON.stringify(payload);
   const payloadAsBuffer = Buffer.from(payloadAsString);
-  const amqpMessage = t.context.getAmqpMessageObject(payloadAsBuffer);
-  const message = new AMQPMessage(amqpMessage, t.context.channel);
+  const { message } = createAmqpMessageMock({ payloadAsBuffer });
 
   t.deepEqual(message.payload, payload);
   t.is(message.getPayloadAsString(), payloadAsString);
@@ -59,75 +27,36 @@ test('get payload object', t => {
   t.deepEqual(message.getPayloadAsBuffer(), payloadAsBuffer);
 });
 
-// @todo implement this behavior in message and in service/client
-test.skip('get payload buffer', t => {
-  const payloadAsBuffer = Buffer.from('myawesomebuffer: 0x12FFFF');
-  const amqpMessage = t.context.getAmqpMessageObject(payloadAsBuffer, 'buffer');
-  const message = new AMQPMessage(amqpMessage, t.context.channel);
+test('application level retry getters', t => {
+  const { message: messageWithRetry } = createAmqpMessageMock({
+    headers: {
+      'X-Retry-Limit': 4,
+    },
+  });
 
-  t.deepEqual(message.payload, payloadAsBuffer);
-  t.is(message.getPayloadAsString(), 'myawesomebuffer: 0x12FFFF');
-  t.throws(() => message.getPayloadAsObject());
-  t.deepEqual(message.getPayloadAsBuffer(), payloadAsBuffer);
+  t.true(messageWithRetry.isApplicationLevelRetryEnabled);
+  t.is(messageWithRetry.applicationLevelRetryLimit, 4);
+
+  const { message: messageWithoutRetry } = createAmqpMessageMock();
+
+  t.false(messageWithoutRetry.isApplicationLevelRetryEnabled);
+  t.is(messageWithoutRetry.applicationLevelRetryLimit, null);
 });
 
-test('correct ack', async t => {
-  t.plan(1);
-  const { channel } = t.context;
+test('application level retry limit setter', t => {
+  const { message, amqpMessageObject } = createAmqpMessageMock({
+    headers: {
+      'X-Retry-Limit': '4',
+    },
+  });
 
-  const amqpMessage = t.context.getAmqpMessageObject(Buffer.from('1'));
+  t.true(message.isApplicationLevelRetryEnabled);
+  t.is(message.applicationLevelRetryLimit, 4);
+  t.is(amqpMessageObject.properties.headers['X-Retry-Limit'], '4');
 
-  channel.ack = async message => {
-    t.is(message, amqpMessage);
-  };
+  message.setApplicationLevelRetryLimit(6);
 
-  const message = new AMQPMessage(amqpMessage, channel);
-
-  await message.ack();
-});
-
-test('correct reject', async t => {
-  t.plan(2);
-  const { channel } = t.context;
-
-  const amqpMessage = t.context.getAmqpMessageObject(Buffer.from('1'));
-
-  channel.reject = async (message, requeue) => {
-    t.is(message, amqpMessage);
-    t.is(requeue, false);
-  };
-
-  const message = new AMQPMessage(amqpMessage, channel);
-
-  await message.reject();
-});
-
-test('correct rejectAndRequeue', async t => {
-  t.plan(2);
-  const { channel } = t.context;
-
-  const amqpMessage = t.context.getAmqpMessageObject(Buffer.from('1'));
-
-  channel.reject = async (message, requeue) => {
-    t.is(message, amqpMessage);
-    t.is(requeue, true);
-  };
-
-  const message = new AMQPMessage(amqpMessage, channel);
-
-  await message.rejectAndRequeue();
-});
-
-test("can't ack or reject already acked/rejected message", async t => {
-  t.plan(2);
-  const { channel } = t.context;
-  channel.reject = async () => {
-    t.pass('rejected');
-  };
-
-  const amqpMessage = t.context.getAmqpMessageObject(Buffer.from('1'));
-  const message = new AMQPMessage(amqpMessage, channel);
-
-  await message.reject();
-  await t.throws(message.reject(), 'Message already acked/rejected or created in sealed mode');
+  t.true(message.isApplicationLevelRetryEnabled);
+  t.is(message.applicationLevelRetryLimit, 6);
+  t.is(amqpMessageObject.properties.headers['X-Retry-Limit'], '6');
 });

--- a/src/AMQPMessageController.js
+++ b/src/AMQPMessageController.js
@@ -1,0 +1,40 @@
+// @flow
+import type { Channel as AMQPChannel } from 'amqplib';
+import AMQPMessage from './AMQPMessage';
+
+class AMQPMessageController {
+  _message: AMQPMessage;
+  _messageSourceChannel: AMQPChannel;
+
+  constructor(message: AMQPMessage) {
+    this._message = message;
+    this._messageSourceChannel = message._channel;
+  }
+
+  async ack() {
+    this._message.checkIsSealed();
+    await this._forceAck();
+  }
+
+  async reject(requeue: ?boolean = false) {
+    this._message.checkIsSealed();
+    await this._forceReject(requeue);
+  }
+
+  async rejectAndRequeue(): Promise<void> {
+    this._message.checkIsSealed();
+    await this._forceReject(true);
+  }
+
+  async _forceAck() {
+    this._messageSourceChannel.ack(this._message._amqpMessage);
+    this._message.toSeal();
+  }
+
+  async _forceReject(requeue: ?boolean = false) {
+    this._messageSourceChannel.reject(this._message._amqpMessage, !!requeue);
+    this._message.toSeal();
+  }
+}
+
+export default AMQPMessageController;

--- a/src/AMQPMessageController.test.js
+++ b/src/AMQPMessageController.test.js
@@ -1,0 +1,82 @@
+/* eslint-disable no-param-reassign */
+import test from 'ava';
+import AMQPMessageController from './AMQPMessageController';
+import { createAmqpMessageMock } from './AMQPMessageMock';
+
+test.beforeEach(t => {
+  const ctx = {};
+  t.context = ctx;
+
+  const { message } = createAmqpMessageMock();
+  ctx.message = message;
+  ctx.channel = message._channel;
+});
+
+test('construct', t => {
+  t.notThrows(() => new AMQPMessageController(t.context.message));
+});
+
+test('correct ack', async t => {
+  t.plan(3);
+  const { channel, message } = t.context;
+  const controller = new AMQPMessageController(message);
+
+  await t.notThrows(controller.ack());
+
+  t.true(channel.ack.calledOnce);
+  t.false(channel.reject.called);
+});
+
+test('correct reject', async t => {
+  t.plan(3);
+  const { channel, message } = t.context;
+  const controller = new AMQPMessageController(message);
+
+  await t.notThrows(controller.reject());
+
+  t.false(channel.ack.called);
+  t.true(channel.reject.calledOnceWith(message._amqpMessage, false));
+});
+
+test('correct rejectAndRequeue', async t => {
+  t.plan(3);
+  const { channel, message } = t.context;
+  const controller = new AMQPMessageController(message);
+
+  await t.notThrows(controller.rejectAndRequeue());
+
+  t.false(channel.ack.called);
+  t.true(channel.reject.calledOnceWith(message._amqpMessage, true));
+});
+
+test("can't ack/reject already acked message", async t => {
+  t.plan(6);
+  const { channel, message } = t.context;
+  const controller = new AMQPMessageController(message);
+
+  await t.notThrows(controller.ack());
+
+  const errorMessage = 'Message already acked/rejected or created in sealed mode';
+  await t.throws(controller.reject(), errorMessage);
+  await t.throws(controller.rejectAndRequeue(), errorMessage);
+  await t.throws(controller.ack(), errorMessage);
+
+  t.true(channel.ack.calledOnce);
+  t.false(channel.reject.called);
+});
+
+test("can't ack/reject already rejected message", async t => {
+  t.plan(6);
+  const { channel, message } = t.context;
+  const controller = new AMQPMessageController(message);
+
+  await t.notThrows(controller.reject());
+
+  const errorMessage = 'Message already acked/rejected or created in sealed mode';
+  await t.throws(controller.reject(), errorMessage);
+  await t.throws(controller.rejectAndRequeue(), errorMessage);
+  await t.throws(controller.ack(), errorMessage);
+
+  t.false(channel.ack.called);
+  t.true(channel.reject.calledOnce);
+});

--- a/src/AMQPMessageMock.js
+++ b/src/AMQPMessageMock.js
@@ -1,0 +1,72 @@
+import uuid from 'uuid/v4';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { stub } from 'sinon';
+import AMQPMessage from './AMQPMessage';
+
+const randomNumber = count => Math.round(Math.random() * count);
+
+export const createChannelMock = () => ({
+  ack: stub().resolves(undefined),
+  reject: stub().resolves(undefined),
+});
+
+export const createAmqpMessageObjectMock = ({
+  payloadAsBuffer,
+  payload = { defaultPayload: 'test' },
+  contentType = 'application/json',
+  headers = {},
+  redelivered = false,
+  routingKey = uuid(),
+  deliveryTag = randomNumber(1e6),
+  correlationId = uuid(),
+  replyTo = uuid(),
+  messageId = uuid(),
+  timestamp = Date.now(),
+  type = uuid(),
+  appId = uuid(),
+} = {}) => ({
+  content: payloadAsBuffer || Buffer.from(JSON.stringify(payload)),
+  fields: {
+    deliveryTag,
+    consumerTag: randomNumber(1e6),
+    exchange: '',
+    routingKey,
+    redelivered,
+  },
+  properties: {
+    expiration: '1000',
+    userId: uuid(),
+    CC: '',
+    priority: 100,
+    persistent: true,
+    contentType,
+    contentEncoding: 'utf-8',
+    headers,
+    correlationId,
+    replyTo,
+    messageId,
+    timestamp,
+    type,
+    appId,
+  },
+});
+
+export const createAmqpMessageMock = (
+  messageProperties,
+  channel = createChannelMock(),
+  sourceQueue = uuid(),
+  isSealed = false,
+) => {
+  const amqpMessageObject = createAmqpMessageObjectMock(messageProperties);
+  const amqpMessage = new AMQPMessage(amqpMessageObject, channel, sourceQueue, isSealed);
+  return {
+    message: amqpMessage,
+    amqpMessage,
+    amqpMessageObject,
+    channel,
+    sourceQueue,
+    isSealed,
+  };
+};
+
+export default createAmqpMessageMock;

--- a/src/AMQPMessageRpcController.js
+++ b/src/AMQPMessageRpcController.js
@@ -1,0 +1,54 @@
+// @flow
+import AMQPMessageController from './AMQPMessageController';
+import AMQPMessage from './AMQPMessage';
+import RpcService from './Service';
+import errorToObject from './rpc/errorToObject';
+
+class AMQPMessageRpcController extends AMQPMessageController {
+  _service: RpcService;
+
+  constructor(message: AMQPMessage, service: RpcService) {
+    super(message);
+    this._service = service;
+  }
+
+  async reply({ payload, error }: { payload?: ?Object, error?: Error }) {
+    const { messageId, correlationId, replyTo } = this._message.props;
+    if (!replyTo) {
+      return;
+    }
+
+    const adapter = this._service._getAdapter();
+    await adapter.send(
+      replyTo,
+      {
+        error: errorToObject(error),
+        payload: payload === undefined ? null : payload,
+      },
+      { messageId, correlationId },
+    );
+  }
+
+  async resendAsRetry() {
+    const { messageId, correlationId, replyTo } = this._message.props;
+
+    const retryLimit = this._message.applicationLevelRetryLimit;
+
+    if (retryLimit === null) {
+      throw new Error('Retry disabled');
+    }
+
+    const adapter = this._service._getAdapter();
+    await adapter.send(this._message.sourceQueue, this._message.payload, {
+      messageId,
+      correlationId,
+      replyTo,
+      headers: {
+        ...this._message.props.headers,
+        'X-Retry-Limit': retryLimit,
+      },
+    });
+  }
+}
+
+export default AMQPMessageRpcController;

--- a/src/AdapterConsumer.js
+++ b/src/AdapterConsumer.js
@@ -9,6 +9,8 @@ opaque type _ConnectOptions = ConnectOptions;
 export default class AdapterConsumer {
   _adapter: ?_AMQPAdapter;
   _connectParams: _ConnectOptions;
+  // @todo: add normal logger injection
+  // eslint-disable-next-line no-console
   _errorHandler: Error => mixed = err => console.error(err);
   _connectPromise: ?Promise<AMQPAdapter> = null;
 

--- a/src/Client.test.js
+++ b/src/Client.test.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-param-reassign */
+import test from 'ava';
+import RpcClient from './Client';
+
+test.beforeEach(t => {
+  const client = new RpcClient({
+    service: '-mock-service-',
+    version: '1.2',
+    defaultRetryLimit: 3,
+  });
+
+  t.context = { client };
+});
+
+test('should correct set default retry limit in constructor and apply on send', async t => {
+  const { client } = t.context;
+
+  t.deepEqual(client._getRetryLimitHeaders(), {
+    'X-Retry-Limit': client._defaultRetryLimit,
+  });
+});
+
+test('should correct receive retry limit in options', async t => {
+  const { client } = t.context;
+
+  t.deepEqual(client._getRetryLimitHeaders({ retryLimit: 5 }), {
+    'X-Retry-Limit': 5,
+  });
+});
+
+test('should empty headers on undefined retry limit in defaults and options', async t => {
+  const { client } = t.context;
+
+  client._defaultRetryLimit = undefined;
+  t.deepEqual(client._getRetryLimitHeaders(), {});
+});

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -29,7 +29,7 @@ test('correct ack message after unsubscribe', async t => {
   await adapter.subscribe(queue, async msg => {
     try {
       await adapter._unsubscribeAll();
-      await msg.ack();
+      await msg._channel.ack(msg._amqpMessage);
       t.pass('message correctly acked after unsubscribe');
     } catch (err) {
       t.fail(err);

--- a/test/retries.js
+++ b/test/retries.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-param-reassign */
+import test from 'ava';
+import uuid from 'uuid/v4';
+import RpcClient from '../src/Client';
+import RpcService from '../src/Service';
+import RpcHandler from '../src/rpc/Handler';
+
+test.beforeEach(async t => {
+  const ctx = {};
+  t.context = ctx;
+
+  ctx.serviceName = uuid();
+  ctx.serviceVersion = '1.0';
+  ctx.connectParams = {
+    url: process.env.RABBITMQ_URL || 'amqp://localhost:5672',
+  };
+
+  ctx.client = new RpcClient({
+    service: ctx.serviceName,
+    version: ctx.serviceVersion,
+    connectParams: ctx.connectParams,
+    defaultRetryLimit: 3,
+  });
+
+  ctx.service = new RpcService({
+    service: ctx.serviceName,
+    version: ctx.serviceVersion,
+    connectParams: ctx.connectParams,
+    queue: {
+      prefetch: 1,
+      durable: true,
+      maxPriority: 100,
+    },
+  });
+
+  await Promise.all([ctx.client.ensureConnection(), ctx.service.ensureConnection()]);
+});
+
+test.afterEach(async t => {
+  const { client, service } = t.context;
+
+  try {
+    await service.destroy();
+  } catch (err) {} // eslint-disable-line no-empty
+
+  try {
+    await client.destroy();
+  } catch (err) {} // eslint-disable-line no-empty
+});
+
+test('should return result when tho fails and one success handle', async t => {
+  t.plan(10);
+  const { client, service } = t.context;
+
+  const payload = { foo: 'bar' };
+  const reply = { bar: 'foo' };
+  let handlerCounter = 0;
+
+  await service.addHandler(
+    class extends RpcHandler {
+      async handle() {
+        handlerCounter += 1;
+        t.deepEqual(this.payload, payload);
+        if (handlerCounter < 3) {
+          throw new Error('Some handler error');
+        }
+        return reply;
+      }
+
+      onFail(err) {
+        t.truthy('on fail called twice');
+        t.is(err.message, 'Some handler error');
+      }
+
+      onSuccess() {
+        t.truthy('on success called once');
+      }
+    },
+  );
+
+  const callResult = await client.send(payload);
+  t.deepEqual(callResult, reply);
+  t.is(handlerCounter, 3);
+});
+
+test('should correct return error to client when retry limit exceeded', async t => {
+  t.plan(8);
+  const { client, service } = t.context;
+
+  await client.ensureConnection();
+  await service.ensureConnection();
+
+  const payload = { foo: 'bar' };
+  let handlerCounter = 0;
+
+  await service.addHandler(
+    class extends RpcHandler {
+      async handle() {
+        handlerCounter += 1;
+        throw new Error('Some handler error');
+      }
+
+      async onFail(err) {
+        t.truthy(err);
+        t.is(err.message, 'Some handler error');
+      }
+    },
+  );
+
+  await t.throws(client.send(payload), 'Some handler error');
+
+  t.is(handlerCounter, 3);
+});


### PR DESCRIPTION
Also:
- extract AMQPMessage mocks
- extract AMQPMessageController with ack/reject methods
- extract AMQPMessageRpcController with reply and resend methods
- some rewrite tests

This commit not introduce breaking changes to out public interface, but your code may be broken if you redefine handleFail private method in service class-based handlers.